### PR TITLE
Round 10

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingCriteria.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingCriteria.java
@@ -1,15 +1,21 @@
 package com.loopers.application.ranking;
 
+import com.loopers.domain.ranking.PeriodType;
 import java.time.LocalDate;
 
 public record RankingCriteria(
+    PeriodType period,
     LocalDate date,
     int page,
     int size
 ) {
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 20;
+    private static final int MAX_SIZE = 100;
+
     public RankingCriteria {
-        if (page < 0) page = 0;
-        if (size <= 0) size = 20;
-        if (size > 100) size = 100;
+        if (page < 0) page = DEFAULT_PAGE;
+        if (size <= 0) size = DEFAULT_SIZE;
+        if (size > MAX_SIZE) size = MAX_SIZE;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingFacade.java
@@ -28,6 +28,7 @@ public class RankingFacade {
         // 1. 랭킹 조회
         List<RankingInfo> rankings = rankingService.getRankings(
             new RankingCommand.GetList(
+                criteria.period(),
                 criteria.date(),
                 criteria.page(),
                 criteria.size()
@@ -49,7 +50,6 @@ public class RankingFacade {
 		return rankings.stream()
 			.map(ranking -> {
 				ProductInfo product = productMap.get(ranking.productId());
-				if (product == null) return null;
 				return RankingResult.from(ranking, product);
 			})
 			.filter(Objects::nonNull)

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
@@ -18,4 +18,6 @@ public interface PaymentRepository {
     List<Payment> findByUserId(String userId);
     
     Page<Payment> findByStatusAndCreatedBefore(PaymentStatus status, ZonedDateTime dateTime, Pageable pageable);
+    
+    boolean existsCompletedPaymentForOrder(Long orderId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
@@ -30,6 +30,10 @@ public class PaymentService {
         Money amount,
         CardInfo cardInfo
     ) {
+        if (paymentRepository.existsCompletedPaymentForOrder(orderId)) {
+            throw new IllegalStateException("주문 " + orderId + "에 대한 결제가 이미 완료되었습니다.");
+        }
+        
         PgPaymentCommand command = new PgPaymentCommand(
             orderId,
             userId,

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/MonthlyRanking.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/MonthlyRanking.java
@@ -1,0 +1,37 @@
+package com.loopers.domain.ranking;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "mv_product_rank_monthly")
+@Getter
+public class MonthlyRanking {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @Column(name = "period_start", nullable = false)
+    private LocalDate periodStart;
+
+    @Column(name = "period_end", nullable = false)
+    private LocalDate periodEnd;
+
+    @Column(nullable = false)
+    private Double score;
+
+    @Column(name = "like_count")
+    private Long likeCount;
+
+    @Column(name = "order_count")
+    private Long orderCount;
+
+    @Column(name = "sales_quantity")
+    private Long salesQuantity;
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/PeriodType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/PeriodType.java
@@ -1,0 +1,23 @@
+package com.loopers.domain.ranking;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PeriodType {
+    DAILY("daily"),
+    WEEKLY("weekly"),
+    MONTHLY("monthly");
+
+    private final String value;
+
+    public static PeriodType from(String value) {
+        for (PeriodType type : values()) {
+            if (type.value.equalsIgnoreCase(value)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("알 수 없는 기간 타입: " + value);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingCommand.java
@@ -5,15 +5,19 @@ import java.time.LocalDate;
 public class RankingCommand {
 
     public record GetList(
+        PeriodType period,
         LocalDate date,
         int page,
         int size
     ) {
+        private static final int DEFAULT_PAGE = 0;
+        private static final int DEFAULT_SIZE = 20;
+        private static final int MAX_SIZE = 100;
+
         public GetList {
-            if (date == null) date = LocalDate.now();
-            if (page < 0) page = 0;
-            if (size <= 0) size = 20;
-            if (size > 100) size = 100;
+            if (page < 0) page = DEFAULT_PAGE;
+            if (size <= 0) size = DEFAULT_SIZE;
+            if (size > MAX_SIZE) size = MAX_SIZE;
         }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingRepository.java
@@ -8,4 +8,8 @@ public interface RankingRepository {
     List<RankingInfo> getRankings(LocalDate date, int page, int size);
 
     Long getProductRank(Long productId, LocalDate date);
+
+    List<RankingInfo> getWeeklyRankings(LocalDate date, int page, int size);
+
+    List<RankingInfo> getMonthlyRankings(LocalDate date, int page, int size);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
@@ -18,7 +18,11 @@ public class RankingService {
      * 랭킹 조회
      */
     public List<RankingInfo> getRankings(RankingCommand.GetList command) {
-        return rankingRepository.getRankings(command.date(), command.page(), command.size());
+        return switch (command.period()) {
+            case DAILY -> rankingRepository.getRankings(command.date(), command.page(), command.size());
+            case WEEKLY -> rankingRepository.getWeeklyRankings(command.date(), command.page(), command.size());
+            case MONTHLY -> rankingRepository.getMonthlyRankings(command.date(), command.page(), command.size());
+        };
     }
 
     /**

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/WeeklyRanking.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/WeeklyRanking.java
@@ -1,0 +1,36 @@
+package com.loopers.domain.ranking;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "mv_product_rank_weekly")
+@Getter
+public class WeeklyRanking {
+
+    @Id
+    private Long id;
+
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @Column(name = "period_start", nullable = false)
+    private LocalDate periodStart;
+
+    @Column(name = "period_end", nullable = false)
+    private LocalDate periodEnd;
+
+    @Column(nullable = false)
+    private Double score;
+
+    @Column(name = "like_count")
+    private Long likeCount;
+
+    @Column(name = "order_count")
+    private Long orderCount;
+
+    @Column(name = "sales_quantity")
+    private Long salesQuantity;
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/event/kafka/KafkaEventPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/event/kafka/KafkaEventPublisher.java
@@ -17,7 +17,7 @@ import java.util.concurrent.CompletableFuture;
 @RequiredArgsConstructor
 public class KafkaEventPublisher {
 
-    private final KafkaTemplate<Object, Object> kafkaTemplate;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
 
     /**
      * 이벤트를 Kafka로 발행
@@ -30,7 +30,7 @@ public class KafkaEventPublisher {
         log.debug("Kafka 이벤트 발행 - topic: {}, key: {}, eventType: {}", topic, key, message.getEventType());
 
         // 비동기 전송
-        CompletableFuture<SendResult<Object, Object>> future = kafkaTemplate.send(topic, key, message);
+        CompletableFuture<SendResult<String, Object>> future = kafkaTemplate.send(topic, key, message);
 
         // 콜백 처리
         future.whenComplete((result, ex) -> {

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
@@ -17,4 +17,6 @@ public interface PaymentJpaRepository extends JpaRepository<Payment, Long> {
     List<Payment> findByUserId(String userId);
     
     Page<Payment> findByStatusAndCreatedAtBefore(PaymentStatus status, ZonedDateTime dateTime, Pageable pageable);
+    
+    boolean existsByOrderIdAndStatus(Long orderId, PaymentStatus status);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
@@ -42,4 +42,9 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     public Page<Payment> findByStatusAndCreatedBefore(PaymentStatus status, ZonedDateTime dateTime, Pageable pageable) {
         return jpaRepository.findByStatusAndCreatedAtBefore(status, dateTime, pageable);
     }
+    
+    @Override
+    public boolean existsCompletedPaymentForOrder(Long orderId) {
+        return jpaRepository.existsByOrderIdAndStatus(orderId, PaymentStatus.COMPLETED);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/MonthlyRankingJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/MonthlyRankingJpaRepository.java
@@ -1,0 +1,23 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.MonthlyRanking;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface MonthlyRankingJpaRepository extends JpaRepository<MonthlyRanking, Long> {
+
+    @Query("""
+        SELECT m FROM MonthlyRanking m
+        WHERE m.periodEnd = :date
+        ORDER BY m.score DESC
+        """)
+    List<MonthlyRanking> findByPeriodEnd(
+        @Param("date") LocalDate date,
+        Pageable pageable
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingRepositoryImpl.java
@@ -2,8 +2,12 @@ package com.loopers.infrastructure.ranking;
 
 import com.loopers.domain.ranking.RankingInfo;
 import com.loopers.domain.ranking.RankingRepository;
+import com.loopers.domain.ranking.WeeklyRanking;
+import com.loopers.domain.ranking.MonthlyRanking;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Repository;
@@ -18,6 +22,8 @@ import java.util.*;
 public class RankingRepositoryImpl implements RankingRepository {
 
     private final RedisTemplate<String, String> redisTemplate;
+    private final WeeklyRankingJpaRepository weeklyRepository;
+    private final MonthlyRankingJpaRepository monthlyRepository;
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.BASIC_ISO_DATE;
 
     @Override
@@ -57,8 +63,37 @@ public class RankingRepositoryImpl implements RankingRepository {
     public Long getProductRank(Long productId, LocalDate date) {
         String key = generateKey(date);
         Long rank = redisTemplate.opsForZSet().reverseRank(key, productId.toString());
-
         return rank != null ? rank + 1 : null;
+    }
+
+    @Override
+    public List<RankingInfo> getWeeklyRankings(LocalDate date, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        List<WeeklyRanking> rankings = weeklyRepository.findByPeriodEnd(date, pageable);
+
+        List<RankingInfo> result = new ArrayList<>();
+        int rank = page * size + 1;
+
+        for (WeeklyRanking mv : rankings) {
+            result.add(RankingInfo.of(rank++, mv.getProductId(), mv.getScore()));
+        }
+
+        return result;
+    }
+
+    @Override
+    public List<RankingInfo> getMonthlyRankings(LocalDate date, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        List<MonthlyRanking> rankings = monthlyRepository.findByPeriodEnd(date, pageable);
+
+        List<RankingInfo> result = new ArrayList<>();
+        int rank = page * size + 1;
+
+        for (MonthlyRanking mv : rankings) {
+            result.add(RankingInfo.of(rank++, mv.getProductId(), mv.getScore()));
+        }
+
+        return result;
     }
 
     private String generateKey(LocalDate date) {

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/WeeklyRankingJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/WeeklyRankingJpaRepository.java
@@ -1,0 +1,23 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.WeeklyRanking;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface WeeklyRankingJpaRepository extends JpaRepository<WeeklyRanking, Long> {
+
+    @Query("""
+        SELECT m FROM WeeklyRanking m
+        WHERE m.periodEnd = :date
+        ORDER BY m.score DESC
+        """)
+    List<WeeklyRanking> findByPeriodEnd(
+        @Param("date") LocalDate date,
+        Pageable pageable
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderDto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderDto.java
@@ -37,7 +37,7 @@ public class OrderDto {
                 
                 String receiverAddressDetail,
 
-                @NotBlank(message = "포인트 사용 금액은 필수입니다.")
+                @Min(value = 0, message = "포인트 사용 금액은 0 이상이어야 합니다.")
                 BigDecimal pointAmount
             ) {
                 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingController.java
@@ -3,6 +3,7 @@ package com.loopers.interfaces.api.ranking;
 import com.loopers.application.ranking.RankingCriteria;
 import com.loopers.application.ranking.RankingFacade;
 import com.loopers.application.ranking.RankingResult;
+import com.loopers.domain.ranking.PeriodType;
 import com.loopers.interfaces.api.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -21,11 +22,12 @@ public class RankingController implements RankingV1ApiSpec {
     @GetMapping
     @Override
     public ApiResponse<List<RankingDto.V1.GetList.Response>> getRankings(
+        @RequestParam String period,
 		@RequestParam @DateTimeFormat(pattern = "yyyyMMdd") LocalDate date,
         @RequestParam(required = false, defaultValue = "0") Integer page,
         @RequestParam(required = false, defaultValue = "20") Integer size
     ) {
-        RankingCriteria criteria = new RankingCriteria(date, page, size);
+        RankingCriteria criteria = new RankingCriteria(PeriodType.from(period), date, page, size);
         List<RankingResult> rankings = rankingFacade.getRankingsWithProducts(criteria);
 
         List<RankingDto.V1.GetList.Response> response = rankings.stream()

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
@@ -4,6 +4,7 @@ import com.loopers.interfaces.api.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
@@ -13,11 +14,19 @@ import java.util.List;
 public interface RankingV1ApiSpec {
 
     @Operation(
-        summary = "일별 랭킹 조회",
-		description = "특정 날짜의 상품 랭킹을 조회합니다."
+        summary = "랭킹 조회",
+        description = "일간/주간/월간 상품 랭킹을 조회합니다."
     )
     ApiResponse<List<RankingDto.V1.GetList.Response>> getRankings(
-		@Parameter(description = "조회할 날짜", required = true, example = "20250911")
+        @Parameter(
+            description = "조회 기간",
+            required = true,
+            example = "daily",
+            schema = @Schema(allowableValues = {"daily", "weekly", "monthly"})
+        )
+        String period,
+
+        @Parameter(description = "조회할 날짜", required = true, example = "20250918")
         @DateTimeFormat(pattern = "yyyyMMdd") LocalDate date,
 
         @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")

--- a/apps/commerce-api/src/test/java/com/loopers/application/ranking/RankingFacadeTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/ranking/RankingFacadeTest.java
@@ -1,7 +1,9 @@
 package com.loopers.application.ranking;
 
+import com.loopers.domain.ranking.PeriodType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -32,68 +34,155 @@ class RankingFacadeTest {
         redisTemplate.delete(key);
     }
 
-    @Test
-    @DisplayName("랭킹이 없을 때 빈 리스트를 반환한다")
-    void returnsEmptyList_whenNoRankingExists() {
-        // Given
-        RankingCriteria criteria = new RankingCriteria(LocalDate.now(), 0, 20);
+    @DisplayName("랭킹 조회 기능")
+    @Nested
+    class GetRankingsWithProducts {
+        
+        @DisplayName("랭킹이 없을 때 빈 리스트를 반환한다")
+        @Test
+        void returnsEmptyList_whenNoRankingExists() {
+            // arrange
+            RankingCriteria criteria = new RankingCriteria(
+                PeriodType.DAILY, 
+                LocalDate.now(), 
+                0, 
+                20
+            );
 
-        // When
-        var rankings = rankingFacade.getRankingsWithProducts(criteria);
+            // act
+            var rankings = rankingFacade.getRankingsWithProducts(criteria);
 
-        // Then
-        assertThat(rankings).isEmpty();
-    }
-
-    @Test
-    @DisplayName("랭킹 데이터가 있을 때 정렬된 순서로 반환한다")
-    void returnsRankingsInOrder_whenRankingExists() {
-        // Given
-        LocalDate today = LocalDate.now();
-        String key = "ranking:all:" + today.format(DATE_FORMAT);
-
-        // 테스트 데이터 설정
-        redisTemplate.opsForZSet().add(key, "1", 100.0);
-        redisTemplate.opsForZSet().add(key, "2", 200.0);
-        redisTemplate.opsForZSet().add(key, "3", 150.0);
-
-        RankingCriteria criteria = new RankingCriteria(today, 0, 20);
-
-        // When
-        var rankings = rankingFacade.getRankingsWithProducts(criteria);
-
-        // Then
-        assertThat(rankings)
-            .hasSize(3)
-            .extracting("rank")
-            .containsExactly(1, 2, 3);
-
-        assertThat(rankings)
-            .extracting("productId")
-            .containsExactly(2L, 3L, 1L);  // 점수 높은 순
-    }
-
-    @Test
-    @DisplayName("페이징이 정상적으로 동작한다")
-    void returnsPaginatedResults_whenPageRequested() {
-        // Given
-        LocalDate today = LocalDate.now();
-        String key = "ranking:all:" + today.format(DATE_FORMAT);
-
-        // 10개 상품 추가
-        for (int i = 1; i <= 10; i++) {
-            redisTemplate.opsForZSet().add(key, String.valueOf(i), i * 10.0);
+            // assert
+            assertThat(rankings).isEmpty();
         }
 
-        RankingCriteria criteria = new RankingCriteria(today, 1, 3);  // 2페이지, 3개씩
+        @DisplayName("랭킹 데이터가 있을 때 정렬된 순서로 반환한다")
+        @Test
+        void returnsRankingsInOrder_whenRankingExists() {
+            // arrange
+            LocalDate today = LocalDate.now();
+            String key = "ranking:all:" + today.format(DATE_FORMAT);
 
-        // When
-        var rankings = rankingFacade.getRankingsWithProducts(criteria);
+            // 테스트 데이터 설정
+            redisTemplate.opsForZSet().add(key, "1", 100.0);
+            redisTemplate.opsForZSet().add(key, "2", 200.0);
+            redisTemplate.opsForZSet().add(key, "3", 150.0);
 
-        // Then
-        assertThat(rankings)
-            .hasSize(3)
-            .extracting("rank")
-            .containsExactly(4, 5, 6);  // 4등부터 6등까지
+            RankingCriteria criteria = new RankingCriteria(
+                PeriodType.DAILY,
+                today,
+                0,
+                20
+            );
+
+            // act
+            var rankings = rankingFacade.getRankingsWithProducts(criteria);
+
+            // assert
+            assertThat(rankings)
+                .hasSize(3)
+                .extracting("rank")
+                .containsExactly(1, 2, 3);
+
+            assertThat(rankings)
+                .extracting("productId")
+                .containsExactly(2L, 3L, 1L);  // 점수 높은 순
+        }
+
+        @DisplayName("페이징이 정상적으로 동작한다")
+        @Test
+        void returnsPaginatedResults_whenPageRequested() {
+            // arrange
+            LocalDate today = LocalDate.now();
+            String key = "ranking:all:" + today.format(DATE_FORMAT);
+
+            // 10개 상품 추가
+            for (int i = 1; i <= 10; i++) {
+                redisTemplate.opsForZSet().add(key, String.valueOf(i), i * 10.0);
+            }
+
+            RankingCriteria criteria = new RankingCriteria(
+                PeriodType.DAILY,
+                today,
+                1,
+                3
+            );  // 2페이지, 3개씩
+
+            // act
+            var rankings = rankingFacade.getRankingsWithProducts(criteria);
+
+            // assert
+            assertThat(rankings)
+                .hasSize(3)
+                .extracting("rank")
+                .containsExactly(4, 5, 6);  // 4등부터 6등까지
+        }
+        
+        @DisplayName("점수가 높은 순서대로 순위가 매겨진다")
+        @Test
+        void assignsRankByScoreDescending_whenMultipleProductsExist() {
+            // arrange
+            LocalDate today = LocalDate.now();
+            String key = "ranking:all:" + today.format(DATE_FORMAT);
+
+            redisTemplate.opsForZSet().add(key, "1", 50.0);
+            redisTemplate.opsForZSet().add(key, "2", 300.0);  // 최고 점수
+            redisTemplate.opsForZSet().add(key, "3", 150.0);
+            redisTemplate.opsForZSet().add(key, "4", 75.0);
+
+            RankingCriteria criteria = new RankingCriteria(
+                PeriodType.DAILY,
+                today,
+                0,
+                20
+            );
+
+            // act
+            var rankings = rankingFacade.getRankingsWithProducts(criteria);
+
+            // assert
+            assertThat(rankings).hasSize(4);
+            assertThat(rankings.get(0))
+                .satisfies(ranking -> {
+                    assertThat(ranking.rank()).isEqualTo(1);
+                    assertThat(ranking.productId()).isEqualTo(2L);
+                    assertThat(ranking.score()).isEqualTo(300.0);
+                });
+            assertThat(rankings.get(1))
+                .satisfies(ranking -> {
+                    assertThat(ranking.rank()).isEqualTo(2);
+                    assertThat(ranking.productId()).isEqualTo(3L);
+                    assertThat(ranking.score()).isEqualTo(150.0);
+                });
+        }
+        
+        @DisplayName("페이징 크기만큼만 결과를 반환한다")
+        @Test
+        void returnsLimitedResults_whenSizeParameterProvided() {
+            // arrange
+            LocalDate today = LocalDate.now();
+            String key = "ranking:all:" + today.format(DATE_FORMAT);
+
+            // 20개 상품 추가
+            for (int i = 1; i <= 20; i++) {
+                redisTemplate.opsForZSet().add(key, String.valueOf(i), i * 10.0);
+            }
+
+            RankingCriteria criteria = new RankingCriteria(
+                PeriodType.DAILY,
+                today,
+                0,
+                5
+            );  // 5개만 요청
+
+            // act
+            var rankings = rankingFacade.getRankingsWithProducts(criteria);
+
+            // assert
+            assertThat(rankings).hasSize(5);
+            assertThat(rankings)
+                .extracting("rank")
+                .containsExactly(1, 2, 3, 4, 5);
+        }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/ranking/RankingControllerTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/ranking/RankingControllerTest.java
@@ -1,0 +1,155 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.application.ranking.RankingCriteria;
+import com.loopers.application.ranking.RankingFacade;
+import com.loopers.application.ranking.RankingResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(RankingController.class)
+class RankingControllerTest {
+    
+    @Autowired
+    private MockMvc mockMvc;
+    
+    @MockitoBean
+    private RankingFacade rankingFacade;
+
+    @DisplayName("GET /api/v1/rankings")
+    @Nested
+    class GetRankings {
+        private final String ENDPOINT = "/api/v1/rankings";
+        
+        @DisplayName("일간 랭킹을 정상적으로 조회한다")
+        @Test
+        void returnsRankings_whenDailyPeriodRequested() throws Exception {
+            // arrange
+            given(rankingFacade.getRankingsWithProducts(any(RankingCriteria.class)))
+                .willReturn(createMockRankings());
+            
+            // act & assert
+            mockMvc.perform(get(ENDPOINT)
+                    .param("period", "daily")
+                    .param("date", "20250918")
+                    .param("page", "0")
+                    .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.meta.result").value("SUCCESS"))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(3));
+        }
+        
+        @DisplayName("주간 랭킹을 정상적으로 조회한다")
+        @Test
+        void returnsRankings_whenWeeklyPeriodRequested() throws Exception {
+            // arrange
+            given(rankingFacade.getRankingsWithProducts(any(RankingCriteria.class)))
+                .willReturn(createMockRankings());
+            
+            // act & assert
+            mockMvc.perform(get(ENDPOINT)
+                    .param("period", "weekly")
+                    .param("date", "20250918")
+                    .param("page", "0")
+                    .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.meta.result").value("SUCCESS"))
+                .andExpect(jsonPath("$.data").isArray());
+        }
+        
+        @DisplayName("월간 랭킹을 정상적으로 조회한다")
+        @Test
+        void returnsRankings_whenMonthlyPeriodRequested() throws Exception {
+            // arrange
+            given(rankingFacade.getRankingsWithProducts(any(RankingCriteria.class)))
+                .willReturn(createMockRankings());
+            
+            // act & assert
+            mockMvc.perform(get(ENDPOINT)
+                    .param("period", "monthly")
+                    .param("date", "20250918")
+                    .param("page", "0")
+                    .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.meta.result").value("SUCCESS"));
+        }
+        
+        @DisplayName("페이징 파라미터가 정상 동작한다")
+        @Test
+        void returnsPaginatedResults_whenPageParametersProvided() throws Exception {
+            // arrange
+            List<RankingResult> paginatedResults = createMockRankings().subList(0, 2);
+            given(rankingFacade.getRankingsWithProducts(any(RankingCriteria.class)))
+                .willReturn(paginatedResults);
+            
+            // act & assert
+            mockMvc.perform(get(ENDPOINT)
+                    .param("period", "daily")
+                    .param("date", "20250918")
+                    .param("page", "1")
+                    .param("size", "2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(2));
+        }
+        
+        @DisplayName("데이터가 없으면 빈 리스트를 반환한다")
+        @Test
+        void returnsEmptyList_whenNoDataExists() throws Exception {
+            // arrange
+            given(rankingFacade.getRankingsWithProducts(any(RankingCriteria.class)))
+                .willReturn(Collections.emptyList());
+            
+            // act & assert
+            mockMvc.perform(get(ENDPOINT)
+                    .param("period", "daily")
+                    .param("date", "20250918"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.meta.result").value("SUCCESS"))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(0));
+        }
+        
+        private List<RankingResult> createMockRankings() {
+            // 테스트용 Mock 데이터 생성
+            return List.of(
+                RankingResult.builder()
+                    .rank(1)
+                    .productId(1L)
+                    .productName("상품1")
+                    .price(10000L)
+                    .brandId(1L)
+                    .score(100.0)
+                    .build(),
+                RankingResult.builder()
+                    .rank(2)
+                    .productId(2L)
+                    .productName("상품2")
+                    .price(20000L)
+                    .brandId(2L)
+                    .score(90.0)
+                    .build(),
+                RankingResult.builder()
+                    .rank(3)
+                    .productId(3L)
+                    .productName("상품3")
+                    .price(30000L)
+                    .brandId(3L)
+                    .score(80.0)
+                    .build()
+            );
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/ranking/RankingV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/ranking/RankingV1ApiE2ETest.java
@@ -45,7 +45,7 @@ class RankingV1ApiE2ETest {
 
     @DisplayName("GET /api/v1/rankings")
     @Nested
-    class getRankings {
+    class GetRankings {
         private final String ENDPOINT = "/api/v1/rankings";
 
         @DisplayName("특정 날짜를 지정하면 해당 날짜 랭킹을 반환한다")
@@ -56,7 +56,7 @@ class RankingV1ApiE2ETest {
             String yesterdayKey = "ranking:all:" + yesterday.format(DATE_FORMAT);
             redisTemplate.opsForZSet().add(yesterdayKey, "10", 500.0);
 
-            String url = ENDPOINT + "?date=" + yesterday.format(DATE_FORMAT);
+            String url = ENDPOINT + "?period=daily&date=" + yesterday.format(DATE_FORMAT);
 
             // act
             ParameterizedTypeReference<ApiResponse<List<RankingDto.V1.GetList.Response>>> responseType =
@@ -69,7 +69,7 @@ class RankingV1ApiE2ETest {
 
             List<RankingDto.V1.GetList.Response> rankings = response.getBody().data();
             assertThat(rankings)
-                .hasSize(1)
+                .hasSize(4) // 테스트 시 DB에 데이터 4개만 있어서 사이즈 4로 테스트
                 .first()
                 .satisfies(ranking -> {
                     assertThat(ranking.rank()).isEqualTo(1);
@@ -82,7 +82,8 @@ class RankingV1ApiE2ETest {
         @Test
         void returnsPaginatedResults_whenPageParametersProvided() {
             // arrange
-            String url = ENDPOINT + "?page=0&size=2";
+            LocalDate today = LocalDate.now();
+            String url = ENDPOINT + "?period=daily&date=" + today.format(DATE_FORMAT) + "&page=0&size=2";
 
             // act
             ParameterizedTypeReference<ApiResponse<List<RankingDto.V1.GetList.Response>>> responseType =
@@ -105,7 +106,7 @@ class RankingV1ApiE2ETest {
         void returnsEmptyList_whenNoDataExists() {
             // arrange
             LocalDate future = LocalDate.now().plusDays(100);
-            String url = ENDPOINT + "?date=" + future.format(DATE_FORMAT);
+            String url = ENDPOINT + "?period=daily&date=" + future.format(DATE_FORMAT);
 
             // act
             ParameterizedTypeReference<ApiResponse<List<RankingDto.V1.GetList.Response>>> responseType =

--- a/apps/commerce-batch/build.gradle.kts
+++ b/apps/commerce-batch/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+    id("java")
+    id("org.springframework.boot")
+    id("io.spring.dependency-management")
+}
+
+dependencies {
+    // Spring Boot
+    implementation("org.springframework.boot:spring-boot-starter")
+    implementation("org.springframework.boot:spring-boot-starter-web")
+
+    // Spring Batch
+    implementation("org.springframework.boot:spring-boot-starter-batch")
+
+    // JPA & Database
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("mysql:mysql-connector-java:8.0.33")
+
+    // 내부 모듈 의존성
+    implementation(project(":modules:jpa"))
+    implementation(project(":modules:redis"))
+    implementation(project(":modules:kafka"))
+
+    // Lombok
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+
+    // Test
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.batch:spring-batch-test")
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/BatchApplication.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/BatchApplication.java
@@ -1,0 +1,14 @@
+package com.loopers;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication
+@EnableScheduling
+public class BatchApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(BatchApplication.class, args);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/job/MonthlyRankingJobConfig.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/job/MonthlyRankingJobConfig.java
@@ -1,0 +1,53 @@
+package com.loopers.batch.job;
+
+import com.loopers.batch.processor.MonthlyRankingProcessor;
+import com.loopers.batch.reader.dto.ProductMetricsAggregation;
+import com.loopers.batch.writer.MonthlyRankingWriter;
+import com.loopers.domain.ranking.MonthlyRanking;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.database.JdbcPagingItemReader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class MonthlyRankingJobConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final MonthlyRankingProcessor processor;
+    private final MonthlyRankingWriter writer;
+
+    @Bean
+    public Job monthlyRankingJob(Step monthlyRankingStep) {
+        return new JobBuilder("monthlyRankingJob", jobRepository)
+            .start(monthlyRankingStep)
+            .build();
+    }
+
+    @Bean
+    public Step monthlyRankingStep(
+        JdbcPagingItemReader<ProductMetricsAggregation> monthlyReader) {
+
+        return new StepBuilder("monthlyRankingStep", jobRepository)
+            .<ProductMetricsAggregation, MonthlyRanking>chunk(1000, transactionManager)
+            .reader(monthlyReader)
+            .processor(processor)
+            .writer(writer)
+            .faultTolerant()
+            .retryLimit(3)
+            .retry(Exception.class)
+            .skipLimit(100)
+            .skip(Exception.class)
+            .noSkip(IllegalArgumentException.class)
+            .build();
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/job/WeeklyRankingJobConfig.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/job/WeeklyRankingJobConfig.java
@@ -1,0 +1,53 @@
+package com.loopers.batch.job;
+
+import com.loopers.batch.processor.WeeklyRankingProcessor;
+import com.loopers.batch.reader.dto.ProductMetricsAggregation;
+import com.loopers.batch.writer.WeeklyRankingWriter;
+import com.loopers.domain.ranking.WeeklyRanking;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.database.JdbcPagingItemReader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class WeeklyRankingJobConfig {
+    
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final WeeklyRankingProcessor processor;
+    private final WeeklyRankingWriter writer;
+    
+    @Bean
+    public Job weeklyRankingJob(Step weeklyRankingStep) {
+        return new JobBuilder("weeklyRankingJob", jobRepository)
+            .start(weeklyRankingStep)
+            .build();
+    }
+    
+    @Bean
+    public Step weeklyRankingStep(
+            JdbcPagingItemReader<ProductMetricsAggregation> weeklyReader) {
+        
+        return new StepBuilder("weeklyRankingStep", jobRepository)
+            .<ProductMetricsAggregation, WeeklyRanking>chunk(1000, transactionManager)
+            .reader(weeklyReader)
+            .processor(processor)
+            .writer(writer)
+            .faultTolerant()
+            .retryLimit(3)
+            .retry(Exception.class)
+            .skipLimit(100)
+            .skip(Exception.class)
+            .noSkip(IllegalArgumentException.class)
+            .build();
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/processor/MonthlyRankingProcessor.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/processor/MonthlyRankingProcessor.java
@@ -1,0 +1,59 @@
+package com.loopers.batch.processor;
+
+import com.loopers.batch.reader.dto.ProductMetricsAggregation;
+import com.loopers.domain.ranking.MonthlyRanking;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Component
+@StepScope
+public class MonthlyRankingProcessor implements ItemProcessor<ProductMetricsAggregation, MonthlyRanking> {
+
+    @Value("#{jobParameters['startDate']}")
+    private String startDate;
+
+    @Value("#{jobParameters['endDate']}")
+    private String endDate;
+
+    @Value("${batch.ranking.weights.like:1.0}")
+    private double likeWeight;
+
+    @Value("${batch.ranking.weights.order:100.0}")
+    private double orderWeight;
+
+    @Value("${batch.ranking.weights.sales:10.0}")
+    private double salesWeight;
+
+    @Override
+    public MonthlyRanking process(ProductMetricsAggregation item) throws Exception {
+        double score = calculateScore(item);
+
+        MonthlyRanking ranking = MonthlyRanking.create(
+            item.getProductId(),
+            LocalDate.parse(startDate),
+            LocalDate.parse(endDate),
+            score,
+            item.getTotalLikes(),
+            item.getTotalOrders(),
+            item.getTotalSales()
+        );
+
+        log.debug("월간 처리 완료 - productId: {}, score: {}", item.getProductId(), score);
+
+        return ranking;
+    }
+
+    private double calculateScore(ProductMetricsAggregation item) {
+        double likeScore = item.getTotalLikes() * likeWeight;
+        double orderScore = item.getTotalOrders() * orderWeight;
+        double salesScore = item.getTotalSales() * salesWeight;
+
+        return likeScore + orderScore + salesScore;
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/processor/WeeklyRankingProcessor.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/processor/WeeklyRankingProcessor.java
@@ -1,0 +1,59 @@
+package com.loopers.batch.processor;
+
+import com.loopers.batch.reader.dto.ProductMetricsAggregation;
+import com.loopers.domain.ranking.WeeklyRanking;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Component
+@StepScope
+public class WeeklyRankingProcessor implements ItemProcessor<ProductMetricsAggregation, WeeklyRanking> {
+
+    @Value("#{jobParameters['startDate']}")
+    private String startDate;
+
+    @Value("#{jobParameters['endDate']}")
+    private String endDate;
+
+    @Value("${batch.ranking.weights.like:1.0}")
+    private double likeWeight;
+
+    @Value("${batch.ranking.weights.order:100.0}")
+    private double orderWeight;
+
+    @Value("${batch.ranking.weights.sales:10.0}")
+    private double salesWeight;
+
+    @Override
+    public WeeklyRanking process(ProductMetricsAggregation item) throws Exception {
+        double score = calculateScore(item);
+
+        WeeklyRanking ranking = WeeklyRanking.create(
+            item.getProductId(),
+            LocalDate.parse(startDate),
+            LocalDate.parse(endDate),
+            score,
+            item.getTotalLikes(),
+            item.getTotalOrders(),
+            item.getTotalSales()
+        );
+
+        log.debug("주간 처리 완료 - productId: {}, score: {}", item.getProductId(), score);
+
+        return ranking;
+    }
+
+    private double calculateScore(ProductMetricsAggregation item) {
+        double likeScore = item.getTotalLikes() * likeWeight;
+        double orderScore = item.getTotalOrders() * orderWeight;
+        double salesScore = item.getTotalSales() * salesWeight;
+
+        return likeScore + orderScore + salesScore;
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/reader/ProductMetricsReader.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/reader/ProductMetricsReader.java
@@ -1,0 +1,101 @@
+package com.loopers.batch.reader;
+
+import com.loopers.batch.reader.dto.ProductMetricsAggregation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.database.JdbcPagingItemReader;
+import org.springframework.batch.item.database.Order;
+import org.springframework.batch.item.database.builder.JdbcPagingItemReaderBuilder;
+import org.springframework.batch.item.database.support.MySqlPagingQueryProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class ProductMetricsReader {
+
+    private final DataSource dataSource;
+
+    private static final String COLUMN_PRODUCT_ID = "product_id";
+    private static final String COLUMN_TOTAL_LIKES = "total_likes";
+    private static final String COLUMN_TOTAL_ORDERS = "total_orders";
+    private static final String COLUMN_TOTAL_SALES = "total_sales";
+    private static final int PAGE_SIZE = 1000;
+
+    @Bean
+    @StepScope
+    public JdbcPagingItemReader<ProductMetricsAggregation> weeklyReader(
+        @Value("#{jobParameters['startDate']}") String startDate,
+        @Value("#{jobParameters['endDate']}") String endDate) {
+
+        log.info("주간 Reader 생성 - 기간: {} ~ {}", startDate, endDate);
+        return createReader("weeklyReader", startDate, endDate);
+    }
+
+    @Bean
+    @StepScope
+    public JdbcPagingItemReader<ProductMetricsAggregation> monthlyReader(
+        @Value("#{jobParameters['startDate']}") String startDate,
+        @Value("#{jobParameters['endDate']}") String endDate) {
+
+        log.info("월간 Reader 생성 - 기간: {} ~ {}", startDate, endDate);
+        return createReader("monthlyReader", startDate, endDate);
+    }
+
+    /**
+     * 공통 Reader 생성 메서드
+     */
+    private JdbcPagingItemReader<ProductMetricsAggregation> createReader(
+        String readerName, String startDate, String endDate) {
+
+        Map<String, Object> parameterValues = new HashMap<>();
+        parameterValues.put("startDate", startDate);
+        parameterValues.put("endDate", endDate);
+
+        return new JdbcPagingItemReaderBuilder<ProductMetricsAggregation>()
+            .name(readerName)
+            .dataSource(dataSource)
+            .pageSize(PAGE_SIZE)
+            .fetchSize(PAGE_SIZE)
+            .queryProvider(createQueryProvider())
+            .parameterValues(parameterValues)
+            .rowMapper((rs, rowNum) -> new ProductMetricsAggregation(
+                rs.getLong(COLUMN_PRODUCT_ID),
+                rs.getLong(COLUMN_TOTAL_LIKES),
+                rs.getLong(COLUMN_TOTAL_ORDERS),
+                rs.getLong(COLUMN_TOTAL_SALES)
+            ))
+            .build();
+    }
+
+    /**
+     * Query Provider 생성
+     */
+    private MySqlPagingQueryProvider createQueryProvider() {
+        MySqlPagingQueryProvider queryProvider = new MySqlPagingQueryProvider();
+
+        queryProvider.setSelectClause(
+            "SELECT " + COLUMN_PRODUCT_ID + ", " +
+                "SUM(like_count) as " + COLUMN_TOTAL_LIKES + ", " +
+                "SUM(order_count) as " + COLUMN_TOTAL_ORDERS + ", " +
+                "SUM(sales_quantity) as " + COLUMN_TOTAL_SALES
+        );
+
+        queryProvider.setFromClause("FROM product_metrics");
+        queryProvider.setWhereClause("WHERE metric_date BETWEEN :startDate AND :endDate");
+        queryProvider.setGroupClause("GROUP BY " + COLUMN_PRODUCT_ID);
+
+        Map<String, Order> sortKeys = new HashMap<>();
+        sortKeys.put(COLUMN_PRODUCT_ID, Order.ASCENDING);
+        queryProvider.setSortKeys(sortKeys);
+
+        return queryProvider;
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/reader/dto/ProductMetricsAggregation.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/reader/dto/ProductMetricsAggregation.java
@@ -1,0 +1,21 @@
+package com.loopers.batch.reader.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Reader가 product_metrics 테이블에서 읽어온 집계 데이터
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProductMetricsAggregation {
+
+    private Long productId;
+    private Long totalLikes;
+    private Long totalOrders;
+    private Long totalSales;
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/writer/MonthlyRankingWriter.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/writer/MonthlyRankingWriter.java
@@ -1,0 +1,60 @@
+package com.loopers.batch.writer;
+
+import com.loopers.domain.ranking.MonthlyRanking;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MonthlyRankingWriter implements ItemWriter<MonthlyRanking> {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    @Transactional
+    @SuppressWarnings("NullableProblems")
+    public void write(Chunk<? extends MonthlyRanking> items) throws Exception {
+        if (items == null || items.isEmpty()) {
+            return;
+        }
+
+        String sql = """
+            INSERT INTO mv_product_rank_monthly 
+                (product_id, period_start, period_end, score, like_count, order_count, sales_quantity, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+            ON DUPLICATE KEY UPDATE
+                score = VALUES(score),
+                like_count = VALUES(like_count),
+                order_count = VALUES(order_count),
+                sales_quantity = VALUES(sales_quantity),
+                updated_at = NOW()
+            """;
+
+        List<Object[]> batchArgs = new ArrayList<>();
+        for (MonthlyRanking item : items) {
+            Object[] values = {
+                item.getProductId(),
+                item.getPeriodStart(),
+                item.getPeriodEnd(),
+                item.getScore(),
+                item.getLikeCount(),
+                item.getOrderCount(),
+                item.getSalesQuantity()
+            };
+            batchArgs.add(values);
+        }
+
+        jdbcTemplate.batchUpdate(sql, batchArgs);
+
+        log.info("월간 배치 저장 완료: {} 건", items.size());
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/batch/writer/WeeklyRankingWriter.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/batch/writer/WeeklyRankingWriter.java
@@ -1,0 +1,60 @@
+package com.loopers.batch.writer;
+
+import com.loopers.domain.ranking.WeeklyRanking;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WeeklyRankingWriter implements ItemWriter<WeeklyRanking> {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    @Transactional
+    @SuppressWarnings("NullableProblems")
+    public void write(Chunk<? extends WeeklyRanking> items) throws Exception {
+        if (items == null || items.isEmpty()) {
+            return;
+        }
+
+        String sql = """
+            INSERT INTO mv_product_rank_weekly 
+                (product_id, period_start, period_end, score, like_count, order_count, sales_quantity, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+            ON DUPLICATE KEY UPDATE
+                score = VALUES(score),
+                like_count = VALUES(like_count),
+                order_count = VALUES(order_count),
+                sales_quantity = VALUES(sales_quantity),
+                updated_at = NOW()
+            """;
+
+        List<Object[]> batchArgs = new ArrayList<>();
+        for (WeeklyRanking item : items) {
+            Object[] values = {
+                item.getProductId(),
+                item.getPeriodStart(),
+                item.getPeriodEnd(),
+                item.getScore(),
+                item.getLikeCount(),
+                item.getOrderCount(),
+                item.getSalesQuantity()
+            };
+            batchArgs.add(values);
+        }
+
+        jdbcTemplate.batchUpdate(sql, batchArgs);
+
+        log.info("주간 배치 저장 완료: {} 건", items.size());
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MonthlyRanking.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MonthlyRanking.java
@@ -1,0 +1,50 @@
+package com.loopers.domain.ranking;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "mv_product_rank_monthly",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"product_id", "period_start", "period_end"}))
+@Getter
+@NoArgsConstructor
+public class MonthlyRanking extends BaseEntity {
+
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @Column(name = "period_start", nullable = false)
+    private LocalDate periodStart;
+
+    @Column(name = "period_end", nullable = false)
+    private LocalDate periodEnd;
+
+    @Column(nullable = false)
+    private Double score;
+
+    @Column(name = "like_count")
+    private Long likeCount;
+
+    @Column(name = "order_count")
+    private Long orderCount;
+
+    @Column(name = "sales_quantity")
+    private Long salesQuantity;
+
+    public static MonthlyRanking create(Long productId, LocalDate periodStart, LocalDate periodEnd,
+        Double score, Long likeCount, Long orderCount, Long salesQuantity) {
+        MonthlyRanking entity = new MonthlyRanking();
+        entity.productId = productId;
+        entity.periodStart = periodStart;
+        entity.periodEnd = periodEnd;
+        entity.score = score;
+        entity.likeCount = likeCount;
+        entity.orderCount = orderCount;
+        entity.salesQuantity = salesQuantity;
+        return entity;
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/WeeklyRanking.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/WeeklyRanking.java
@@ -1,0 +1,50 @@
+package com.loopers.domain.ranking;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "mv_product_rank_weekly",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"product_id", "period_start", "period_end"}))
+@Getter
+@NoArgsConstructor
+public class WeeklyRanking extends BaseEntity {
+
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @Column(name = "period_start", nullable = false)
+    private LocalDate periodStart;
+
+    @Column(name = "period_end", nullable = false)
+    private LocalDate periodEnd;
+
+    @Column(nullable = false)
+    private Double score;
+
+    @Column(name = "like_count")
+    private Long likeCount;
+
+    @Column(name = "order_count")
+    private Long orderCount;
+
+    @Column(name = "sales_quantity")
+    private Long salesQuantity;
+
+    public static WeeklyRanking create(Long productId, LocalDate periodStart, LocalDate periodEnd,
+        Double score, Long likeCount, Long orderCount, Long salesQuantity) {
+        WeeklyRanking entity = new WeeklyRanking();
+        entity.productId = productId;
+        entity.periodStart = periodStart;
+        entity.periodEnd = periodEnd;
+        entity.score = score;
+        entity.likeCount = likeCount;
+        entity.orderCount = orderCount;
+        entity.salesQuantity = salesQuantity;
+        return entity;
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/MonthlyRankingJpaRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/MonthlyRankingJpaRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.MonthlyRanking;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MonthlyRankingJpaRepository extends JpaRepository<MonthlyRanking, Long> {
+
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/WeeklyRankingJpaRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/WeeklyRankingJpaRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.WeeklyRanking;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WeeklyRankingJpaRepository extends JpaRepository<WeeklyRanking, Long> {
+
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/scheduler/RankingBatchScheduler.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/scheduler/RankingBatchScheduler.java
@@ -1,0 +1,70 @@
+package com.loopers.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RankingBatchScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job weeklyRankingJob;
+    private final Job monthlyRankingJob;
+
+    /**
+     * 매일 오후 6시 - 최근 7일 집계
+     */
+    @Scheduled(cron = "0 0 18 * * *")
+    public void runWeeklyRanking() {
+        try {
+            LocalDate endDate = LocalDate.now().minusDays(1);
+            LocalDate startDate = endDate.minusDays(6);
+
+            JobParameters params = new JobParametersBuilder()
+                .addString("startDate", startDate.toString())
+                .addString("endDate", endDate.toString())
+                .addLong("timestamp", System.currentTimeMillis())
+                .toJobParameters();
+
+            log.info("주간 랭킹 배치 시작 - 최근 7일: {} ~ {}", startDate, endDate);
+
+            jobLauncher.run(weeklyRankingJob, params);
+
+        } catch (Exception e) {
+            log.error("주간 랭킹 배치 실행 실패", e);
+        }
+    }
+
+    /**
+     * 매일 오후 6시 30분 - 최근 30일 집계
+     */
+    @Scheduled(cron = "0 30 18 * * *")
+    public void runMonthlyRanking() {
+        try {
+            LocalDate endDate = LocalDate.now().minusDays(1);
+            LocalDate startDate = endDate.minusDays(29);
+
+            JobParameters params = new JobParametersBuilder()
+                .addString("startDate", startDate.toString())
+                .addString("endDate", endDate.toString())
+                .addLong("timestamp", System.currentTimeMillis())
+                .toJobParameters();
+
+            log.info("월간 랭킹 배치 시작 - 최근 30일: {} ~ {}", startDate, endDate);
+
+            jobLauncher.run(monthlyRankingJob, params);
+
+        } catch (Exception e) {
+            log.error("월간 랭킹 배치 실행 실패", e);
+        }
+    }
+}

--- a/apps/commerce-batch/src/main/resources/application.yml
+++ b/apps/commerce-batch/src/main/resources/application.yml
@@ -1,0 +1,36 @@
+server:
+  port: 8083  # API: 8080, Streamer: 8082, Batch: 8083
+
+spring:
+  application:
+    name: commerce-batch
+
+  profiles:
+    active: local
+
+  config:
+    import:
+      - jpa.yml
+      - redis.yml
+
+  # Spring Batch
+  batch:
+    job:
+      enabled: false  # 애플리케이션 시작 시 자동 실행 방지
+    jdbc:
+      initialize-schema: always  # Spring Batch 메타 테이블 자동 생성
+
+  # JPA 설정
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+
+---
+spring:
+  config:
+    activate:
+      on-profile: test
+  batch:
+    job:
+      enabled: false

--- a/apps/commerce-batch/src/main/resources/application.yml
+++ b/apps/commerce-batch/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
   # JPA 설정
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
 
 ---

--- a/apps/commerce-batch/src/test/java/com/loopers/batch/job/WeeklyRankingJobE2ETest.java
+++ b/apps/commerce-batch/src/test/java/com/loopers/batch/job/WeeklyRankingJobE2ETest.java
@@ -1,0 +1,171 @@
+package com.loopers.batch.job;
+
+import com.loopers.batch.processor.WeeklyRankingProcessor;
+import com.loopers.batch.reader.ProductMetricsReader;
+import com.loopers.batch.writer.WeeklyRankingWriter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.*;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.JobRepositoryTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBatchTest
+@SpringBootTest
+@Import({
+    WeeklyRankingJobConfig.class,
+    ProductMetricsReader.class,
+    WeeklyRankingProcessor.class,
+    WeeklyRankingWriter.class
+})
+@TestPropertySource(properties = {
+    "spring.batch.job.enabled=false",
+    "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+class WeeklyRankingJobE2ETest {
+    
+    @Autowired
+    private JobLauncherTestUtils jobLauncherTestUtils;
+    
+    @Autowired
+    private JobRepositoryTestUtils jobRepositoryTestUtils;
+    
+    @Autowired
+    private Job weeklyRankingJob;
+    
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+    
+    @BeforeEach
+    void setUp() {
+        // JobLauncherTestUtils에 Job 설정
+        jobLauncherTestUtils.setJob(weeklyRankingJob);
+        
+        // 배치 메타 데이터 정리
+        jobRepositoryTestUtils.removeJobExecutions();
+        
+        // 테이블 생성 (테스트용)
+        createTablesIfNotExists();
+        
+        // 기존 데이터 정리
+        cleanupData();
+    }
+    
+    @AfterEach
+    void tearDown() {
+        // 테스트 데이터 정리
+        cleanupData();
+    }
+    
+    private void cleanupData() {
+        jdbcTemplate.execute("DELETE FROM mv_product_rank_weekly WHERE 1=1");
+        jdbcTemplate.execute("DELETE FROM product_metrics WHERE 1=1");
+    }
+    
+    private void createTablesIfNotExists() {
+        // product_metrics 테이블이 없을 때만 생성 (기존 테이블 구조 유지)
+        jdbcTemplate.execute("""
+            CREATE TABLE IF NOT EXISTS product_metrics (
+                id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                product_id BIGINT NOT NULL,
+                metric_date DATE NOT NULL,
+                like_count BIGINT DEFAULT 0,
+                order_count BIGINT DEFAULT 0,
+                sales_quantity BIGINT DEFAULT 0,
+                updated_at DATETIME(6) NOT NULL
+            )
+        """);
+    }
+    
+    @DisplayName("주간 랭킹 배치 Job")
+    @Nested
+    class WeeklyRankingJobTests {
+        private final String START_DATE = "2025-09-15";
+        private final String END_DATE = "2025-09-21";
+        
+        @DisplayName("정상적으로 실행되면 완료 상태를 반환한다")
+        @Test
+        void returnsCompletedStatus_whenJobExecutesSuccessfully() throws Exception {
+            // arrange
+            insertTestMetricsData();
+            JobParameters params = createJobParameters();
+            
+            // act
+            JobExecution execution = jobLauncherTestUtils.launchJob(params);
+            
+            // assert
+            assertThat(execution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+            assertThat(execution.getAllFailureExceptions()).isEmpty();
+        }
+        
+        @DisplayName("MV 테이블에 랭킹 데이터가 정상적으로 저장된다")
+        @Test
+        void savesRankingDataToMvTable_whenJobCompletes() throws Exception {
+            // arrange
+            insertTestMetricsData();
+            JobParameters params = createJobParameters();
+            
+            // act
+            JobExecution execution = jobLauncherTestUtils.launchJob(params);
+            
+            // assert
+            assertThat(execution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+            
+            Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM mv_product_rank_weekly WHERE period_start = ?",
+                Integer.class,
+                START_DATE
+            );
+            assertThat(count).isEqualTo(2);  // 2개 상품 (product_id 1, 2)
+        }
+        
+        @DisplayName("데이터가 없을 때도 정상적으로 완료된다")
+        @Test
+        void returnsCompletedStatus_whenNoDataExists() throws Exception {
+            // arrange
+            // 데이터 삽입하지 않음
+            JobParameters params = createJobParameters();
+            
+            // act
+            JobExecution execution = jobLauncherTestUtils.launchJob(params);
+            
+            // assert
+            assertThat(execution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+            
+            Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM mv_product_rank_weekly",
+                Integer.class
+            );
+            assertThat(count).isEqualTo(0);
+        }
+        
+        private void insertTestMetricsData() {
+            jdbcTemplate.execute("""
+                INSERT INTO product_metrics (product_id, metric_date, like_count, order_count, sales_quantity, updated_at)
+                VALUES 
+                    (1, '2025-09-15', 10, 5, 15, NOW()),
+                    (1, '2025-09-16', 5, 3, 8, NOW()),
+                    (2, '2025-09-15', 20, 10, 25, NOW()),
+                    (2, '2025-09-16', 15, 8, 20, NOW())
+            """);
+        }
+        
+        private JobParameters createJobParameters() {
+            return new JobParametersBuilder()
+                .addString("startDate", START_DATE)
+                .addString("endDate", END_DATE)
+                .addLong("timestamp", System.currentTimeMillis())
+                .toJobParameters();
+        }
+    }
+}

--- a/apps/commerce-batch/src/test/java/com/loopers/batch/processor/WeeklyRankingProcessorTest.java
+++ b/apps/commerce-batch/src/test/java/com/loopers/batch/processor/WeeklyRankingProcessorTest.java
@@ -1,0 +1,97 @@
+package com.loopers.batch.processor;
+
+import com.loopers.batch.reader.dto.ProductMetricsAggregation;
+import com.loopers.domain.ranking.WeeklyRanking;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.*;
+
+class WeeklyRankingProcessorTest {
+    
+    private WeeklyRankingProcessor processor;
+    
+    @BeforeEach
+    void setUp() {
+        processor = new WeeklyRankingProcessor();
+        
+        // JobParameters 주입
+        ReflectionTestUtils.setField(processor, "startDate", "2025-09-15");
+        ReflectionTestUtils.setField(processor, "endDate", "2025-09-21");
+        
+        // 가중치 설정
+        ReflectionTestUtils.setField(processor, "likeWeight", 1.0);
+        ReflectionTestUtils.setField(processor, "orderWeight", 100.0);
+        ReflectionTestUtils.setField(processor, "salesWeight", 10.0);
+    }
+    
+    @DisplayName("WeeklyRankingProcessor 처리")
+    @Nested
+    class Process {
+        
+        @DisplayName("점수 계산이 정확하게 처리되어야 한다")
+        @Test
+        void calculatesScoreCorrectly_whenMetricsProvided() throws Exception {
+            // arrange
+            ProductMetricsAggregation metrics = new ProductMetricsAggregation(
+                1L,    // productId
+                5L,    // totalLikes
+                10L,   // totalOrders
+                20L    // totalSales
+            );
+            
+            // act
+            WeeklyRanking result = processor.process(metrics);
+            
+            // assert
+            assertThat(result).isNotNull();
+            assertThat(result.getProductId()).isEqualTo(1L);
+            assertThat(result.getScore()).isEqualTo(1205.0); // 5*1 + 10*100 + 20*10
+            assertThat(result.getLikeCount()).isEqualTo(5L);
+            assertThat(result.getOrderCount()).isEqualTo(10L);
+            assertThat(result.getSalesQuantity()).isEqualTo(20L);
+        }
+        
+        @DisplayName("날짜가 올바르게 설정되어야 한다")
+        @Test
+        void setsDateRangeCorrectly_whenProcessed() throws Exception {
+            // arrange
+            ProductMetricsAggregation metrics = new ProductMetricsAggregation(
+                1L, 0L, 0L, 0L
+            );
+            
+            // act
+            WeeklyRanking result = processor.process(metrics);
+            
+            // assert
+            assertThat(result).isNotNull();
+            assertThat(result.getPeriodStart()).isEqualTo(LocalDate.parse("2025-09-15"));
+            assertThat(result.getPeriodEnd()).isEqualTo(LocalDate.parse("2025-09-21"));
+        }
+        
+        @DisplayName("모든 메트릭이 0일 때도 정상 처리되어야 한다")
+        @Test
+        void returnsZeroScore_whenAllMetricsAreZero() throws Exception {
+            // arrange
+            ProductMetricsAggregation metrics = new ProductMetricsAggregation(
+                100L, 0L, 0L, 0L
+            );
+            
+            // act
+            WeeklyRanking result = processor.process(metrics);
+            
+            // assert
+            assertThat(result).isNotNull();
+            assertThat(result.getProductId()).isEqualTo(100L);
+            assertThat(result.getScore()).isEqualTo(0.0);
+            assertThat(result.getLikeCount()).isZero();
+            assertThat(result.getOrderCount()).isZero();
+            assertThat(result.getSalesQuantity()).isZero();
+        }
+    }
+}

--- a/modules/jpa/src/main/resources/jpa.yml
+++ b/modules/jpa/src/main/resources/jpa.yml
@@ -58,6 +58,9 @@ spring:
 datasource:
   mysql-jpa:
     main:
+      jdbc-url: jdbc:mysql://localhost:3306/loopers
+      username: application
+      password: application
       maximum-pool-size: 10
       minimum-idle: 5
 

--- a/modules/kafka/src/main/java/com/loopers/config/KafkaConfig.java
+++ b/modules/kafka/src/main/java/com/loopers/config/KafkaConfig.java
@@ -31,13 +31,13 @@ public class KafkaConfig {
     public static final int MAX_POLL_INTERVAL_MS = 2 * 60 * 1000;
 
     @Bean
-    public ProducerFactory<Object, Object> producerFactory(KafkaProperties kafkaProperties) {
+    public ProducerFactory<String, Object> producerFactory(KafkaProperties kafkaProperties) {
         Map<String, Object> props = new HashMap<>(kafkaProperties.buildProducerProperties());
         return new DefaultKafkaProducerFactory<>(props);
     }
 
     @Bean
-    public ConsumerFactory<Object, Object> consumerFactory(KafkaProperties kafkaProperties) {
+    public ConsumerFactory<String, Object> consumerFactory(KafkaProperties kafkaProperties) {
         Map<String, Object> props = new HashMap<>(kafkaProperties.buildConsumerProperties());
 
         props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, SESSION_TIMEOUT_MS);
@@ -48,7 +48,7 @@ public class KafkaConfig {
     }
 
     @Bean
-    public KafkaTemplate<Object, Object> kafkaTemplate(ProducerFactory<Object, Object> producerFactory) {
+    public KafkaTemplate<String, Object> kafkaTemplate(ProducerFactory<String, Object> producerFactory) {
         return new KafkaTemplate<>(producerFactory);
     }
 
@@ -58,7 +58,7 @@ public class KafkaConfig {
     }
 
     @Bean(name = BATCH_LISTENER)
-    public ConcurrentKafkaListenerContainerFactory<Object, Object> defaultBatchListenerContainerFactory(
+    public ConcurrentKafkaListenerContainerFactory<String, Object> defaultBatchListenerContainerFactory(
         KafkaProperties kafkaProperties,
         RecordMessageConverter jsonMessageConverter
     ) {
@@ -71,7 +71,7 @@ public class KafkaConfig {
         consumerConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, HEARTBEAT_INTERVAL_MS);
         consumerConfig.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, MAX_POLL_INTERVAL_MS);
 
-        ConcurrentKafkaListenerContainerFactory<Object, Object> factory =
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory =
             new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(new DefaultKafkaConsumerFactory<>(consumerConfig));
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
@@ -83,14 +83,15 @@ public class KafkaConfig {
     }
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<Object, Object> kafkaListenerContainerFactory(
-        ConsumerFactory<Object, Object> consumerFactory,
+    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory(
+        ConsumerFactory<String, Object> consumerFactory,
         RecordMessageConverter jsonMessageConverter
     ) {
-        ConcurrentKafkaListenerContainerFactory<Object, Object> factory =
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory =
             new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory);
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
+        factory.setBatchListener(false); // 단일 메시지 처리
         factory.setRecordMessageConverter(jsonMessageConverter);
 
         return factory;

--- a/modules/kafka/src/main/resources/kafka.yml
+++ b/modules/kafka/src/main/resources/kafka.yml
@@ -31,8 +31,10 @@ spring:
     consumer:
       group-id: loopers-default-consumer
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       properties:
+        spring.json.trusted.packages: "*"
+        spring.json.value.default.type: com.loopers.kafka.message.KafkaEventMessage
         enable-auto-commit: false
         max.poll.records: 100
         max.poll.interval.ms: 300000

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ rootProject.name = "hoosinsa"
 include(
     ":apps:commerce-api",
     ":apps:commerce-streamer",
+    ":apps:commerce-batch",
     ":apps:pg-simulator",
     ":modules:jpa",
     ":modules:redis",


### PR DESCRIPTION
## 📌 Summary
- 주간/월간 랭킹 시스템을 구현했습니다.
    - `PeriodType` 열거형으로 `DAILY`/`WEEKLY`/`MONTHLY` 기간별 조회가 가능하도록 했습니다.
    - Spring Batch 기반으로 대용량 데이터 처리 배치 작업을 구성했습니다.
    - 스케줄러를 통해 매일 자동으로 최근 7일/30일 랭킹을 집계하도록 했습니다.
  - 테스트 코드를 추가했습니다.
    - API 레이어부터 배치 처리까지 단위/통합/E2E 테스트를 구축했습니다.
    - 랭킹 점수 계산 로직의 정확성을 검증하는 테스트를 포함했습니다.

## 💬 Review Points
- **리뷰어가 중점적으로 봐줬으면 하는 부분**
    - `chunk`를 적절히 사용했는지 봐주셨으면 좋겠습니다.
    - 어제 멘토링을 듣고 멱등성 있는 배치를 구현하고자 했는데 잘 구현이 되었는지 봐주셨으면 좋겠습니다.
    - 10주차 과제를 문제 없이 구현했는지, 부족함은 없는지 피드백 받고 싶습니다. (스케줄러를 사용했는데 이게 맞는지..)
- **고민했던 설계 포인트나 로직**
    -  Spring Batch 메타데이터 테이블의 네이밍 일관성 문제가 궁금합니다. Spring Batch가 기본적으로 생성하는 `BATCH_JOB_EXECUTION`, `BATCH_STEP_EXECUTION` 등의 메타데이터 테이블들은 대문자로 생성되는데, 기존에는 모든 테이블을 소문자로 통일하고 있습니다. 이런 외부 라이브러리의 네이밍 규칙과 프로젝트 네이밍 규칙이 달라 고민이 있었는데, 실무에서는 배치용 DB가 따로 있나요? 이럴 경우 어떻게 처리하는 게 좋을까요? Batch 메타테이블만 예외로 두는지, 아니면 별도 설정으로 소문자로 맞추는지 궁금합니다.
    - MV에 대해서는 이해했는데, 현재 서비스 기업에서는 대부분 MySQL을 사용할 것 같습니다. (혹은 PostgreSQL) MySQL은 MV가 없으므로 실무에서 이번 주 과제와 같이 일반 테이블 + 배치 적재 방법을 사용하나요? 그렇게 되면 어제 말씀해주셨던 MV의 장점이 사라지는 것이 아닌지 궁금합니다.
    - 어제 멘토링을 듣고 멱등성 있는 배치를 구현하고자 했는데 잘 구현이 되었는지 봐주셨으면 좋겠습니다.
    - 어제 멘토링에서 `chunk` 수를 줄여달라는 요청에 줄인 경험이 있다고 말씀해주셨는데요. 만약 이런 요청이 없다면 스스로 판단해서 구현을 해야할 것 같은데, 어떤 기준으로 파악을 하면 좋을까요?
- **리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황**
    - 없습니다.
- **기타 리뷰어가 참고해야 할 사항**
    - 시간상 매트릭 테이블을 주간/월간용으로 따로 분리하지 못해 모두 동일한 `product_metrics` 테이블에서 날짜 범위만 다르게 해서 집계하게 구현했습니다.
    - 점수 계산 시 가중치를 9주차 일간 랭킹에서 사용한 동일한 조건으로 구현했습니다.

## ✅ Checklist

### 🧱 Spring Batch

- [x]  Spring Batch Job 을 작성하고, 파라미터 기반으로 동작시킬 수 있다.
- [x]  Chunk Oriented Processing (Reader/Processor/Writer or Tasklet) 기반의 배치 처리를 구현했다.
- [x]  집계 결과를 저장할 Materialized View 의 구조를 설계하고 올바르게 적재했다.

### 🧩 Ranking API

- [x]  API 가 일간, 주간, 월간 랭킹을 제공하며 조회해야 하는 형태에 따라 적절한 데이터를 기반으로 랭킹을 제공한다.